### PR TITLE
Add files via upload

### DIFF
--- a/FSTR/DBpereval/serializers.py
+++ b/FSTR/DBpereval/serializers.py
@@ -40,7 +40,6 @@ class PerevalSerializer(WritableNestedModelSerializer):
         model = Pereval
         fields = ['beauty_title', 'title', 'other_titles', 'connect', 'add_time', 'status', 'user', 'coords',
                   'level', 'images']
-        read_only_fields = ['status']
 
     def create(self, validated_data, **kwargs):
         user = validated_data.pop('user')

--- a/FSTR/DBpereval/views.py
+++ b/FSTR/DBpereval/views.py
@@ -69,6 +69,6 @@ class PerevalViewset(viewsets.ModelViewSet):
         else:
             return Response({
                 'state': '0',
-                'message': f'Отклонено! Причина: статус объекта должен быть {pereval.get_status_display()}'
+                'message': f'Отклонено! Причина: статус объекта должен быть "new", текущий статус - "{pereval.get_status_display()}"'
             })
 


### PR DESCRIPTION
Changed Meta fields in PerevalSerializer to exclude "read-only" option for status. Changed partial_update function message in the PerevalViewset to more clearly specify the error: Отклонено! Причина: статус объекта должен быть "new", текущий статус - "{pereval.get_status_display()}"